### PR TITLE
FIX: avoid using current() on objects as it's deprecated

### DIFF
--- a/src/Drivers/VectoryLinkDriver.php
+++ b/src/Drivers/VectoryLinkDriver.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace RobustTools\Resala\Drivers;
 
 use RobustTools\Resala\Abstracts\Driver;
@@ -52,29 +53,27 @@ final class VectoryLinkDriver extends Driver implements SMSDriverInterface
 
     public function send(): SMSDriverResponseInterface
     {
-        $response = HTTP::get($this->endPoint, $this->headers(), $this->payload());
+        $response = HTTP::post($this->endPoint, $this->headers(), $this->payload());
 
         return new VectoryLinkResponse($response);
     }
 
-    protected function payload(): array
+    protected function payload(): string
     {
-        return
-            [
-                "SMSText" => $this->message,
-                "SMSReceiver" => $this->recipients,
-                "SMSSender" => $this->senderName,
-                'SMSLang' => $this->lang,
-                'UserName' => $this->username,
-                'Password' => $this->password
-            ];
+        return http_build_query([
+            "SMSText" => $this->message,
+            "SMSReceiver" => $this->recipients,
+            "SMSSender" => $this->senderName,
+            'SMSLang' => $this->lang,
+            'UserName' => $this->username,
+            'Password' => $this->password
+        ]);
     }
 
     protected function headers(): array
     {
         return [
-            'Content-Type' => 'text/xml; charset=utf-8',
-            'Content-Length' => 0
+            'Content-Type' => 'application/x-www-form-urlencoded'
         ];
     }
 }

--- a/src/Response/VectoryLinkResponse.php
+++ b/src/Response/VectoryLinkResponse.php
@@ -32,7 +32,7 @@ final class VectoryLinkResponse implements SMSDriverResponseInterface
     public function __construct(ResponseInterface $response)
     {
         $this->response = new SimpleXMLElement($response->getBody());
-        $this->status = (int) current($this->response);
+        $this->status = (int) current(get_mangled_object_vars($this->response));
     }
 
     public function success(): bool

--- a/src/Support/ConfigRepository.php
+++ b/src/Support/ConfigRepository.php
@@ -79,7 +79,7 @@ final class ConfigRepository implements ArrayAccess
         return $this->has($offset);
     }
 
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return $this->get($offset);
     }


### PR DESCRIPTION
Use `get_mangled_object_vars()` with the `current()` to avoid a deprecation warning caused by using an object with `current()` function

_Reference: https://www.php.net/manual/en/migration81.deprecated.php#migration81.deprecated.standard_