### PR TITLE
feat: add compatibility for Laravel 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "ext-json": "*",
         "ext-simplexml": "*",
         "guzzlehttp/guzzle": "^7.5",
-        "illuminate/support": "^9.0|^10"
+        "illuminate/support": "^9.0|^10|^11.0"
     },
     "require-dev": {
         "orchestra/testbench": "^8.0.8",

--- a/tests/SMSDriverFactoryTest.php
+++ b/tests/SMSDriverFactoryTest.php
@@ -1,0 +1,32 @@
+<?php
+namespace RobustTools\Resala\Tests;
+
+use Orchestra\Testbench\TestCase as OrchestraTestCase;
+use RobustTools\Resala\Contracts\SMSDriverInterface;
+use RobustTools\Resala\Factories\SMSDriverFactory;
+use RobustTools\Resala\SMSServiceProvider;
+
+class SMSDriverFactoryTest extends OrchestraTestCase
+{
+    /**
+     * Get package providers.
+     *
+     * @param  \Illuminate\Foundation\Application  $app
+     * @return array
+     */
+    protected function getPackageProviders($app): array
+    {
+        return [
+            SMSServiceProvider::class,
+        ];
+    }
+    public function testCreatMethod()
+    {
+        \Mockery::mock('alias:' . SMSDriverFactory::class)
+                ->shouldReceive('create')
+                ->once()
+                ->andReturn(\Mockery::mock(SMSDriverInterface::class));;
+
+        SMSDriverFactory::create();
+    }
+}

--- a/tests/SMSTest.php
+++ b/tests/SMSTest.php
@@ -1,15 +1,19 @@
 <?php
 namespace RobustTools\Resala\Tests;
 
+use Mockery;
 use Orchestra\Testbench\TestCase as OrchestraTestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+use RobustTools\Resala\Contracts\SMSDriverInterface;
 use RobustTools\Resala\Contracts\SMSDriverResponseInterface;
 use RobustTools\Resala\Facades\SMS as SMSFacade;
-use RobustTools\Resala\SMS;
 use RobustTools\Resala\SMSServiceProvider;
-
 class SMSTest extends OrchestraTestCase
 {
-
+    private $mockXmlResponse;
+    private $mockStream;
+    private $mockResponse;
     /**
      * Get package providers.
      *
@@ -24,9 +28,66 @@ class SMSTest extends OrchestraTestCase
     }
     public function testSMS()
     {
-        $this->smsMock = \Mockery::mock(SMS::class)->shouldReceive('via','to','message','send')
-            ->andReturn(\Mockery::mock(SMSDriverResponseInterface::class));;
-        (new SMS)->via('vodafone')->to('01000000000')->message("test")->send();
+        $sms = $this->createMockXMLResponse()
+                    ->createMockStream()
+                    ->createMockResponse()
+                    ->mockHTTP()
+                    ->sendSMS();
 
+        $this->assertInstanceOf(SMSDriverResponseInterface::class, $sms);
+
+    }
+
+    private function createMockXMLResponse(): self
+    {
+        $this->mockXmlResponse = <<<XML
+                                <?xml version="1.0" encoding="UTF-8"?>
+                                    <Response>
+                                    </Response>
+                                XML;
+        return $this;
+    }
+
+    private function createMockStream(): self
+    {
+        $this->mockStream = Mockery::mock(StreamInterface::class);
+        $this->mockStream->shouldReceive('__toString')
+            ->andReturn($this->mockXmlResponse);
+        $this->mockStream->shouldReceive('getContents')
+            ->andReturn($this->mockXmlResponse);
+        return $this;
+    }
+
+    private function createMockResponse(): self
+    {
+        $this->mockResponse = Mockery::mock(ResponseInterface::class);
+        $this->mockResponse
+             ->shouldReceive('getBody')
+             ->andReturn($this->mockStream);
+        $this->mockResponse
+             ->shouldReceive('getStatusCode')
+             ->andReturn(200);
+        $this->mockResponse
+             ->shouldReceive('getHeaders')
+             ->andReturn([
+                 'Content-Type' => ['application/xml; charset=UTF8']
+             ]);
+        return $this;
+    }
+
+    private function mockHTTP(): self
+    {
+        Mockery::mock('alias:RobustTools\Resala\Support\HTTP')
+            ->shouldReceive('post')
+            ->andReturn($this->mockResponse);
+        return $this;
+    }
+
+    private function sendSMS()
+    {
+        return SMSFacade::via('vodafone')
+                        ->to('01000000000')
+                        ->message("test")
+                        ->send();
     }
 }

--- a/tests/SMSTest.php
+++ b/tests/SMSTest.php
@@ -1,0 +1,32 @@
+<?php
+namespace RobustTools\Resala\Tests;
+
+use Orchestra\Testbench\TestCase as OrchestraTestCase;
+use RobustTools\Resala\Contracts\SMSDriverResponseInterface;
+use RobustTools\Resala\Facades\SMS as SMSFacade;
+use RobustTools\Resala\SMS;
+use RobustTools\Resala\SMSServiceProvider;
+
+class SMSTest extends OrchestraTestCase
+{
+
+    /**
+     * Get package providers.
+     *
+     * @param  \Illuminate\Foundation\Application  $app
+     * @return array
+     */
+    protected function getPackageProviders($app): array
+    {
+        return [
+            SMSServiceProvider::class,
+        ];
+    }
+    public function testSMS()
+    {
+        $this->smsMock = \Mockery::mock(SMS::class)->shouldReceive('via','to','message','send')
+            ->andReturn(\Mockery::mock(SMSDriverResponseInterface::class));;
+        (new SMS)->via('vodafone')->to('01000000000')->message("test")->send();
+
+    }
+}

--- a/tests/SMSTest.php
+++ b/tests/SMSTest.php
@@ -5,7 +5,6 @@ use Mockery;
 use Orchestra\Testbench\TestCase as OrchestraTestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
-use RobustTools\Resala\Contracts\SMSDriverInterface;
 use RobustTools\Resala\Contracts\SMSDriverResponseInterface;
 use RobustTools\Resala\Facades\SMS as SMSFacade;
 use RobustTools\Resala\SMSServiceProvider;


### PR DESCRIPTION
**Summary:**
- **Updated Illuminate/Support version**: The `illuminate/support` package version has been updated from `^9.0|^10` to `^9.0|^10|^11.0` to ensure compatibility with Laravel 11 and future-proof the application.
  
- **Added Mock Test for SMSDriverFactory**: Implemented a mock test for the `SMSDriverFactory` to simulate the behavior of the SMS service and ensure correct handling of dependencies during testing.

- **Added Mock Test for SMS Final Class**: Created mock tests for the `SMS` final class, overcoming the limitations of mocking final classes by using partial mocks. This ensures that HTTP requests made by the SMS service are skipped during tests, improving test isolation and performance.
