### PR TITLE
feat: upgrade to latest vectorylink REST/json APIs & updated response codes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "ext-json": "*",
         "ext-simplexml": "*",
         "guzzlehttp/guzzle": "^7.5",
-        "illuminate/support": "^9.0|^10"
+        "illuminate/support": "^9.0|^10|^11.0"
     },
     "require-dev": {
         "orchestra/testbench": "^8.0.8",

--- a/src/Drivers/VectoryLinkDriver.php
+++ b/src/Drivers/VectoryLinkDriver.php
@@ -3,8 +3,7 @@
 namespace RobustTools\Resala\Drivers;
 
 use RobustTools\Resala\Abstracts\Driver;
-use RobustTools\Resala\Contracts\SMSDriverInterface;
-use RobustTools\Resala\Contracts\SMSDriverResponseInterface;
+use RobustTools\Resala\Contracts\{SMSDriverInterface, SMSDriverResponseInterface};
 use RobustTools\Resala\Response\VectoryLinkResponse;
 use RobustTools\Resala\Support\HTTP;
 
@@ -54,27 +53,38 @@ final class VectoryLinkDriver extends Driver implements SMSDriverInterface
 
     public function send(): SMSDriverResponseInterface
     {
-        $response = HTTP::post($this->endPoint, $this->headers(), $this->payload());
-
-        return new VectoryLinkResponse($response);
+        return new VectoryLinkResponse(HTTP::post($this->endPoint, $this->headers(), json_encode($this->payload())));
     }
 
-    protected function payload(): string
+    /**
+     * @return array<string, mixed>
+     */
+    protected function payload(): array
     {
-        return http_build_query([
-            "SMSText" => $this->message,
-            "SMSReceiver" => $this->recipients,
-            "SMSSender" => $this->senderName,
+        return [
+            'SMSText' => $this->message,
+            'SMSReceiver' => $this->recipients,
+            'SMSSender' => $this->senderName,
             'SMSLang' => $this->lang,
             'UserName' => $this->username,
-            'Password' => $this->password
-        ]);
+            'Password' => $this->password,
+            'SMSID' => $this->generateGuid(),
+        ];
+    }
+
+    private function generateGuid(): string
+    {
+        $data = random_bytes(16);
+        $data[6] = chr(ord($data[6]) & 0x0f | 0x40);
+        $data[8] = chr(ord($data[8]) & 0x3f | 0x80);
+
+        return vsprintf('%s%s-%s-%s-%s-%s%s%s', str_split(bin2hex($data), 4));
     }
 
     protected function headers(): array
     {
         return [
-            'Content-Type' => 'application/x-www-form-urlencoded'
+            'Content-Type' => 'application/json',
         ];
     }
 }

--- a/src/Response/VectoryLinkResponse.php
+++ b/src/Response/VectoryLinkResponse.php
@@ -4,56 +4,76 @@ namespace RobustTools\Resala\Response;
 
 use Psr\Http\Message\ResponseInterface;
 use RobustTools\Resala\Contracts\SMSDriverResponseInterface;
-use SimpleXMLElement;
 
 final class VectoryLinkResponse implements SMSDriverResponseInterface
 {
-    private const OK = 0;
-
-    private const USER_ERR = -1;
-
-    private const CREDIT_ERR = -5;
-
-    private const OK_QUEUED = -10;
-
-    private const LANG_ERR = -11;
-
-    private const SMS_ERR = -12;
-
-    private const SENDER_ERR = -13;
-
-    private const SENDING_RATE_ERR = -25;
-
-    private const GENERIC_ERR = -100;
-
-    private SimpleXMLElement $response;
+    private const STATUS_SUCCESS = 0;
+    private const STATUS_INVALID_CREDENTIALS = -1;
+    private const STATUS_INVALID_ACCOUNT_IP = -2;
+    private const STATUS_INVALID_ANI_BLACK_LIST = -3;
+    private const STATUS_OUT_OF_CREDIT = -5;
+    private const STATUS_DATABASE_DOWN = -6;
+    private const STATUS_INACTIVE_ACCOUNT = -7;
+    private const STATUS_ACCOUNT_EXPIRED = -11;
+    private const STATUS_SMS_EMPTY = -12;
+    private const STATUS_INVALID_SENDER_WITH_CONNECTION = -13;
+    private const STATUS_SMS_SENDING_FAILED = -14;
+    private const STATUS_OTHER_ERROR = -100;
+    private const STATUS_INVALID_ANI = -18;
+    private const STATUS_SMS_ID_EXISTS = -19;
+    private const STATUS_INVALID_ACCOUNT = -21;
+    private const STATUS_SMS_NOT_VALIDATE = -22;
+    private const STATUS_INVALID_ACCOUNT_OPERATOR_CONNECTION = -23;
+    private const STATUS_INVALID_USER_SMS_ID = -26;
+    private const STATUS_EMPTY_USERNAME_OR_PASSWORD = -29;
+    private const STATUS_INVALID_SENDER = -30;
 
     private int $status;
 
     public function __construct(ResponseInterface $response)
     {
-        $this->response = new SimpleXMLElement($response->getBody());
-        $this->status = (int) current(get_mangled_object_vars($this->response));
+        $contents = trim($response->getBody()->getContents());
+        $this->status = $this->parseStatus($contents);
+    }
+
+    private function parseStatus(string $contents): int
+    {
+        if ($contents === '' || !is_numeric($contents)) {
+            return self::STATUS_OTHER_ERROR;
+        }
+        return (int) $contents;
     }
 
     public function success(): bool
     {
-        return $this->status === self::OK
-            || $this->status === self::OK_QUEUED;
+        return $this->status === self::STATUS_SUCCESS;
     }
 
     public function body(): string
     {
-        return [
-            self::OK => 'Message Sent Successfully',
-            self::USER_ERR => 'User is not subscribed',
-            self::CREDIT_ERR => 'Out of credit.',
-            self::OK_QUEUED => 'Queued Message, no need to send it again.',
-            self::LANG_ERR => 'Invalid language.',
-            self::SMS_ERR => 'SMS is empty.',
-            self::SENDER_ERR => 'Invalid fake sender exceeded 12 chars or empty.',
-            self::SENDING_RATE_ERR => 'Sending rate greater than receiving rate (only for send/receive accounts).',
-            self::GENERIC_ERR => 'Other error',
-        ][$this->status] ?? 'Something wrong happened';
+        $messages = [
+            self::STATUS_SUCCESS => 'Success',
+            self::STATUS_INVALID_CREDENTIALS => 'Invalid Credentials',
+            self::STATUS_INVALID_ACCOUNT_IP => 'Invalid Account IP',
+            self::STATUS_INVALID_ANI_BLACK_LIST => 'Invalid ANI Black List',
+            self::STATUS_OUT_OF_CREDIT => 'Out Of Credit',
+            self::STATUS_DATABASE_DOWN => 'Database Down',
+            self::STATUS_INACTIVE_ACCOUNT => 'Inactive Account',
+            self::STATUS_ACCOUNT_EXPIRED => 'Account Is Expired',
+            self::STATUS_SMS_EMPTY => 'SMS Is Empty',
+            self::STATUS_INVALID_SENDER_WITH_CONNECTION => 'Invalid Sender With Connection',
+            self::STATUS_SMS_SENDING_FAILED => 'SMS Sending Failed Try Again',
+            self::STATUS_OTHER_ERROR => 'Other Error',
+            self::STATUS_INVALID_ANI => 'Invalid ANI',
+            self::STATUS_SMS_ID_EXISTS => 'SMS Id Is Exist',
+            self::STATUS_INVALID_ACCOUNT => 'Invalid Account',
+            self::STATUS_SMS_NOT_VALIDATE => 'SMS Not Validate',
+            self::STATUS_INVALID_ACCOUNT_OPERATOR_CONNECTION => 'Invalid Account Operator Connection',
+            self::STATUS_INVALID_USER_SMS_ID => 'Invalid User SMS Id',
+            self::STATUS_EMPTY_USERNAME_OR_PASSWORD => 'Empty User Name Or Password',
+            self::STATUS_INVALID_SENDER => 'Invalid Sender',
+        ];
+
+        return $messages[$this->status] ?? 'Something wrong happened';
     }
 }


### PR DESCRIPTION
# Merge Request: VectoryLink driver – upgrade to latest API

## Why

The VectoryLink API was updated: requests must use **JSON** (`Content-Type: application/json`) instead of form-encoded, and each message must include a unique **SMSID** (GUID). The response is now a **plain integer** status code (no XML/JSON wrapper). The previous driver and response handling were outdated and caused wrong behaviour (e.g. server error HTML parsed as status `0` and treated as success).

## What was done

### VectoryLinkDriver.php

- **Request format**: Switched from `application/x-www-form-urlencoded` to `application/json`. Payload is built as an array and sent as `json_encode($this->payload())`.
- **SMSID**: Added `SMSID` to every request – generated as a new GUID (v4) per message via `generateGuid()`.
- **Payload**: `payload()` now returns an array (same keys: SMSText, SMSReceiver, SMSSender, SMSLang, UserName, Password, plus SMSID). `send()` passes `json_encode($this->payload())` to `HTTP::post` in one line.

### VectoryLinkResponse.php

- **Parsing**: Response body is a single int. Removed XML/JSON key logic; we now `trim(getBody()->getContents())` and parse as int. No `Status` / `Code` keys.
- **Invalid body**: When the body is empty or non-numeric (e.g. 500 HTML), we no longer cast to `0` and mark as success. `parseStatus($contents)` returns `STATUS_OTHER_ERROR` (-100) in that case so `success()` is false and `body()` returns "Other Error".
- **Status codes**: Constants and `body()` message map updated to match the current API (0 Success, -1 Invalid Credentials, -2 Invalid Account IP, -3, -5, -6, -7, -11, -12, -13, -14, -18, -19, -21, -22, -23, -26, -29, -30, -100 Other Error). `success()` is only true for status `0`.

## How

| File                 | Change |
|----------------------|--------|
| `VectoryLinkDriver`  | Headers `Content-Type: application/json`; payload array with `SMSID` (GUID v4); body = `json_encode($this->payload())`. |
| `VectoryLinkResponse`| Read body as string → `parseStatus()`: if empty or non-numeric → -100, else `(int) $contents`. Use new constants and message map; `success()` only for `0`. |

## References

- https://smsvas.vlserv.com/VLSMSPlatformResellerAPI/SendSMSService/SMSSender.asmx?op=SendSMS
- [VictoryLink API Technical document V1.4.pdf](https://github.com/user-attachments/files/25589736/VictoryLink.API.Technical.document.V1.4.pdf)
